### PR TITLE
Action inputs/outputs/args/entry improvements

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,5 @@
 FROM hashicorp/terraform
+RUN apk add --no-cache python3 bash
 COPY . ./benchmarks
-ENTRYPOINT ["/benchmarks/entry-point.sh"]
+WORKDIR /benchmarks
+ENTRYPOINT ["/benchmarks/entry-point.py"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,3 @@
 FROM hashicorp/terraform
-
-COPY files /benchmarks/files
-COPY entry-point.sh /benchmarks/
-
+COPY . ./benchmarks
 ENTRYPOINT ["/benchmarks/entry-point.sh"]

--- a/action.yaml
+++ b/action.yaml
@@ -10,23 +10,16 @@ inputs:
   aws-secret-key:
     description: 'AWS secret key to create perfomance tests environment'
     required: true
-  adapter:
-    description: 'Artipie adapter to test'
-    required: true
-  scenario:
-    description: 'JMeter scenario file to execute'
-    required: true
   version:
     description: 'Docker tag of Artipie image to test'
     required: true
+outputs:
+  report:
+    description: 'Report containing JSON file with benchmarking results'
 runs:
   using: 'docker'
   image: Dockerfile
   env:
+    ARTIPIE_VERSION: ${{ inputs.version }}
     TF_VAR_access_key: ${{ inputs.aws-access-key }}
     TF_VAR_secret_key: ${{ inputs.aws-secret-key }}
-  args:
-    - ${{ inputs.adapter }}
-    - ${{ inputs.scenario }}
-    - artipie
-    - ${{ inputs.version }}

--- a/entry-point.py
+++ b/entry-point.py
@@ -33,7 +33,7 @@ for directory in directories:
     file = open("benchmark-results.json", "r")
     dict_merge(json.loads(file.read()), result)
     file.close()
-    os.chdir("..")
+    os.chdir("-")
 
 # Write result into a file
 json_str = json.dumps(result)

--- a/entry-point.py
+++ b/entry-point.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+
+import os
+import subprocess
+import collections
+import json
+
+
+def dict_merge(dct, merge_dct):
+    """ Recursive dict merge.
+    :param dct: dict onto which the merge is executed
+    :param merge_dct: dct merged into dct
+    :return: None
+    """
+    for key, value in merge_dct.items():
+        if (key in dct and isinstance(dct[key], dict)
+                and isinstance(merge_dct[key], collections.Mapping)):
+            dict_merge(dct[key], merge_dct[key])
+        else:
+            dct[key] = merge_dct[key]
+
+
+# Directories included into benchmarking suit
+directories = ["sample"]
+
+# JSON data, containing all the benchmarking results
+result = {}
+
+# Run benchmarks for each directory and collect everything into a single JSON
+for directory in directories:
+    os.chdir(directory)
+    subprocess.run(["bash", "-x", "run.sh"])
+    file = open("benchmark-results.json", "r")
+    dict_merge(json.loads(file.read()), result)
+    file.close()
+    os.chdir("..")
+
+# Write result into a file
+json_str = json.dumps(result)
+file = open("benchmark-results.json", "w+")
+file.write(json_str)
+file.close()
+# Fill Github Action output variable
+subprocess.run(["echo", f"::set-output name=report::benchmark-results.json"])

--- a/entry-point.sh
+++ b/entry-point.sh
@@ -1,9 +1,0 @@
-#!/bin/sh
-if [ $# -lt 4 ]
-then
-  echo >&2 "Usage: ./entry-point.sh <adapter> <jmeter-scenario-file> (artipie|sonatype) <version>"
-  exit 1
-fi
-
-/bin/sh $(dirname "$0")/$1/run.sh $2 $3 $4
-cp -fr $(dirname "$0")/$1/report $GITHUB_WORKSPACE

--- a/sample/run.sh
+++ b/sample/run.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+echo '{}' > benchmark-results.json


### PR DESCRIPTION
The amount of inputs/args has been reduced. The only action output should be a JSON report which contains all the benchmarking results per run. This JSON file will be used for results visualisation on Github Actions.

This PR includes:

* New entry point written in Python. It collects all the benchmarking results in a single JSON file and set required GitHub actions output.
* Improved action with new output and no useless parameters.

Related to #21.