### PR TITLE
Docker benchmarks results reported properly

### DIFF
--- a/docker/run.sh
+++ b/docker/run.sh
@@ -32,7 +32,7 @@ ssh ubuntu@$PUBLIC_CLIENT_IP_ADDR "source instance-env.sh; /home/ubuntu/upload.p
 ssh ubuntu@$PUBLIC_SERVER_IP_ADDR "source instance-env.sh; /home/ubuntu/upload.py stop_registry"
 
 # Download results
-scp ubuntu@$PUBLIC_SERVER_IP_ADDR:/home/ubuntu/*.json ./
+scp ubuntu@$PUBLIC_CLIENT_IP_ADDR:/home/ubuntu/*.json ./
 
 # Stop AWS infrastructure
 ../aws-infrastructure/stop.sh

--- a/docker/upload.py
+++ b/docker/upload.py
@@ -19,9 +19,10 @@ def run(args):
     subprocess.run(args, check=True)
 
 
-def start_artipie():
+def start_artipie(version=os.getenv("ARTIPIE_VERSION", "latest")):
     """
     Start artipie docker image
+    :param version: The artipie version to start
     :return: nothing
     """
     print("Starting artipie")
@@ -49,7 +50,7 @@ repo:
         f.write(my_docker)
     run([
         "bash", "-c",
-        "docker run -d --rm --name artipie -it -v $(pwd)/artipie.yaml:/etc/artipie.yml -v $(pwd):/var/artipie -p 8080:80 artipie/artipie:latest"
+        f"docker run -d --rm --name artipie -it -v $(pwd)/artipie.yaml:/etc/artipie.yml -v $(pwd):/var/artipie -p 8080:80 artipie/artipie:{version}"
     ])
 
 
@@ -121,7 +122,7 @@ def upload_benchmark(images, address, registry):
         time = measure(lambda: run(push))
         print(f"Pushing {full_image}; Elapsed: {time}")
         result["docker"]["single-upload"][registry]["images"].append({image: time})
-    with open(f"benchmark-results-{registry}.json", "w+") as f:
+    with open(f"{registry}-benchmark-results.json", "w+") as f:
         f.write(json.dumps(result, indent=4, sort_keys=True))
 
 

--- a/entry-point.py
+++ b/entry-point.py
@@ -33,14 +33,12 @@ if __name__ == '__main__':
         os.chdir(directory)
         subprocess.run(["bash", "-x", "run.sh"])
         for bench_result in glob.glob("*benchmark-results.json"):
-            file = open(bench_result, "r")
-            dict_merge(result, json.loads(file.read()))
-            file.close()
+            with open(bench_result, "r") as file:
+                dict_merge(result, json.loads(file.read()))
         os.chdir("..")
 
     # Write result into a file
     with open("benchmark-results.json", "w+") as file:
         file.write(json.dumps(result, indent=4, sort_keys=True))
-        file.close()
     # Fill Github Action output variable
     subprocess.run(["echo", f"::set-output name=report::benchmark-results.json"])

--- a/entry-point.py
+++ b/entry-point.py
@@ -2,8 +2,9 @@
 
 import os
 import subprocess
-import collections
+import collections.abc
 import json
+import glob
 
 
 def dict_merge(dct, merge_dct):
@@ -14,31 +15,32 @@ def dict_merge(dct, merge_dct):
     """
     for key, value in merge_dct.items():
         if (key in dct and isinstance(dct[key], dict)
-                and isinstance(merge_dct[key], collections.Mapping)):
+                and isinstance(merge_dct[key], collections.abc.Mapping)):
             dict_merge(dct[key], merge_dct[key])
         else:
             dct[key] = merge_dct[key]
 
 
-# Directories included into benchmarking suit
-directories = ["sample"]
+if __name__ == '__main__':
+    # Directories included into benchmarking suit
+    directories = ["docker", "sample"]
 
-# JSON data, containing all the benchmarking results
-result = {}
+    # JSON data, containing all the benchmarking results
+    result = {}
 
-# Run benchmarks for each directory and collect everything into a single JSON
-for directory in directories:
-    os.chdir(directory)
-    subprocess.run(["bash", "-x", "run.sh"])
-    file = open("benchmark-results.json", "r")
-    dict_merge(json.loads(file.read()), result)
-    file.close()
-    os.chdir("-")
+    # Run benchmarks for each directory and collect everything into a single JSON
+    for directory in directories:
+        os.chdir(directory)
+        subprocess.run(["bash", "-x", "run.sh"])
+        for bench_result in glob.glob("*benchmark-results.json"):
+            file = open(bench_result, "r")
+            dict_merge(result, json.loads(file.read()))
+            file.close()
+        os.chdir("..")
 
-# Write result into a file
-json_str = json.dumps(result)
-file = open("benchmark-results.json", "w+")
-file.write(json_str)
-file.close()
-# Fill Github Action output variable
-subprocess.run(["echo", f"::set-output name=report::benchmark-results.json"])
+    # Write result into a file
+    with open("benchmark-results.json", "w+") as file:
+        file.write(json.dumps(result, indent=4, sort_keys=True))
+        file.close()
+    # Fill Github Action output variable
+    subprocess.run(["echo", f"::set-output name=report::benchmark-results.json"])


### PR DESCRIPTION
With this PR:

* entry point now collects all results ending with `*benchmark-results.json`
* results for docker benchmarks are properly collected from a client machine(instead of the server)
* artipie version for docker benchmark is taken from env varible

Related to #18 and #21