### PR TITLE
fix: script and `benchmarks.json` according to existed archives

### DIFF
--- a/adapters/Makefile
+++ b/adapters/Makefile
@@ -26,5 +26,4 @@ prepare: generate
         /bin/bash ./script.sh prepare $(TARGET)
 
 run: generate build prepare
-        @echo !!run
         /bin/bash ./script.sh run $(TARGET)

--- a/adapters/Makefile
+++ b/adapters/Makefile
@@ -1,32 +1,30 @@
-
 BENCH_SOURCE=benchmarks.json
 TARGET=helm
 
-.PHONY: all clean run generate build prepare distclean
+.PHONY: all outclean clone run generate build prepare distclean
 
 all: distclean run
 
-distclean: clean generate
-	./script.sh clean
-	rm -fr script.sh
+distclean: outclean
+        /bin/bash ./script.sh clean $(TARGET)
 
-clean:
-	rm -fr out
-	rm -f script.sh
+outclean:
+        rm -fr out/$(TARGET)
 
 generate:
-	rm -f script.sh
-	./generate.py $(BENCH_SOURCE) > script.sh
-	chmod +x script.sh
+        rm -f script.sh
+        /bin/env python3 ./generate.py $(BENCH_SOURCE) > script.sh
+        chmod +x script.sh
 
 clone: generate
-	./script.sh clone $(TARGET)
+        /bin/bash ./script.sh clone $(TARGET)
 
-build: clone
-	./script.sh build $(TARGET)
+build: distclean clone
+        /bin/bash ./script.sh build $(TARGET)
 
 prepare: generate
-	./script.sh prepare $(TARGET)
+        /bin/bash ./script.sh prepare $(TARGET)
 
-run: build prepare
-	./script.sh run $(TARGET)
+run: generate build prepare
+        @echo !!run
+        /bin/bash ./script.sh run $(TARGET)

--- a/adapters/Makefile
+++ b/adapters/Makefile
@@ -6,24 +6,24 @@ TARGET=helm
 all: distclean run
 
 distclean: outclean
-        /bin/bash ./script.sh clean $(TARGET)
+		/bin/bash ./script.sh clean $(TARGET)
 
 outclean:
-        rm -fr out/$(TARGET)
+		rm -fr out/$(TARGET)
 
 generate:
-        rm -f script.sh
-        /bin/env python3 ./generate.py $(BENCH_SOURCE) > script.sh
-        chmod +x script.sh
+		rm -f script.sh
+		/bin/env python3 ./generate.py $(BENCH_SOURCE) > script.sh
+		chmod +x script.sh
 
 clone: generate
-        /bin/bash ./script.sh clone $(TARGET)
+		/bin/bash ./script.sh clone $(TARGET)
 
 build: distclean clone
-        /bin/bash ./script.sh build $(TARGET)
+		/bin/bash ./script.sh build $(TARGET)
 
 prepare: generate
-        /bin/bash ./script.sh prepare $(TARGET)
+		/bin/bash ./script.sh prepare $(TARGET)
 
 run: generate build prepare
-        /bin/bash ./script.sh run $(TARGET)
+		/bin/bash ./script.sh run $(TARGET)

--- a/adapters/benchmarks.json
+++ b/adapters/benchmarks.json
@@ -10,21 +10,24 @@
                                         "class": "org.openjdk.jmh.Main",
                                         "data": "https://artipie.s3.amazonaws.com/rpm-test/bundle100.tar.gz",
                                         "args": ["RpmBench"],
-                                        "output": "rpm-batch-update.txt"
+                                        "output": "rpm-batch-update.txt",
+                                        "path-in-tar": "bundle100/"
                                 },
                                 {
                                         "name": "Remove",
                                         "class": "org.openjdk.jmh.Main",
                                         "data": "https://artipie.s3.amazonaws.com/rpm-test/centos-7-os-x86_64-repodata.tar.gz",
                                         "args": ["RpmMetadataRemoveBench"],
-                                        "output": "rpm-remove.txt"
+                                        "output": "rpm-remove.txt",
+                                        "path-in-tar": ""
                                 },
                                 {
                                         "name": "Append",
                                         "class": "org.openjdk.jmh.Main",
                                         "data": "https://artipie.s3.amazonaws.com/rpm-test/rpm-metadata-append-bench.tar.gz",
                                         "args": ["RpmMetadataAppendBench"],
-                                        "output": "rpm-append.txt"
+                                        "output": "rpm-append.txt",
+                                        "path-in-tar": "Downloads/rpm-metadata-append-bench/"
                                 }
                         ]
                 }
@@ -40,20 +43,21 @@
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["IndexMergeBench"],
                                         "data": "https://artipie.s3.amazonaws.com/debian-test/debian-merge.tar.gz",
-                                        "output": "debian-merge-index.txt"
+                                        "output": "debian-merge-index.txt",
+                                        "path-in-tar": "Downloads/deb-merge/"
                                 },
                                 {
                                         "name": "Repo update",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["RepoUpdateBench"],
                                         "data": "https://artipie.s3.amazonaws.com/debian-test/debian-repo.tar.gz",
-                                        "output": "debian-merge-index.txt"
+                                        "output": "debian-merge-index.txt",
+                                        "path-in-tar": "Downloads/deb-packages/"
                                 }
                         ]
                 }
         },
         "helm": {
-                "name": "Helm adapter",
                 "repo": "https://github.com/artipie/helm-adapter.git",
                 "benchmarks": {
                         "path": "benchmarks",
@@ -63,21 +67,24 @@
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["HelmAstoRemoveBench"],
                                         "data": "https://artipie.s3.amazonaws.com/helm-test/helm100.tar.gz",
-                                        "output": "helm-remove.txt"
+                                        "output": "helm-remove.txt",
+                                        "path-in-tar": "bundle100/"
                                 },
                                 {
                                         "name": "Helm add",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["HelmAstoAddBench"],
                                         "data": "https://artipie.s3.amazonaws.com/helm-test/helm100.tar.gz",
-                                        "output": "helm-add.txt"
+                                        "output": "helm-add.txt",
+                                        "path-in-tar": "bundle100/"
                                 },
                                 {
                                         "name": "Helm reindex",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["HelmAstoReindexBench"],
                                         "data": "https://artipie.s3.amazonaws.com/helm-test/helm100.tar.gz",
-                                        "output": "helm-reindex.txt"
+                                        "output": "helm-reindex.txt",
+                                        "path-in-tar": "bundle100/"
                                 }
                         ]
                 }
@@ -93,21 +100,24 @@
                                         "class": "org.openjdk.jmh.Main",
                                         "data": "https://artipie.s3.amazonaws.com/conda-test/conda-remove.tar.gz",
                                         "args": ["CondaRepodataRemoveBench"],
-                                        "output": "conda-remove.txt"
+                                        "output": "conda-remove.txt",
+                                        "path-in-tar": ""
                                 },
                                 {
                                         "name": "Append",
                                         "class": "org.openjdk.jmh.Main",
                                         "data": "https://artipie.s3.amazonaws.com/conda-test/conda-append.tar.gz",
                                         "args": ["CondaRepodataAppendBench"],
-                                        "output": "conda-append.txt"
+                                        "output": "conda-append.txt",
+                                        "path-in-tar": ""
                                 },
                                 {
                                         "name": "Merge",
                                         "class": "org.openjdk.jmh.Main",
                                         "data": "https://artipie.s3.amazonaws.com/conda-test/conda-merge.tar.gz",
                                         "args": ["MultiRepodataBench"],
-                                        "output": "conda-merge.txt"
+                                        "output": "conda-merge.txt",
+                                        "path-in-tar": ""
                                 }
                         ]
                 }

--- a/adapters/generate.py
+++ b/adapters/generate.py
@@ -63,12 +63,11 @@ for name in data:
                     echo "Data `{tar}` already exists with correct md5sum. It is not necessary to download with curl again."
                 else
                     curl {url} > {tar}
-                    tar -xvzf $W/_{name}_case{cnt}.tar.gz -C $W/_{name}_case{cnt}
                 fi
             else
                 curl {url} > {tar}
-                tar -xvzf $W/_{name}_case{cnt}.tar.gz -C $W/_{name}_case{cnt}
             fi
+            tar -xvzf $W/_{name}_case{cnt}.tar.gz -C $W/_{name}_case{cnt}
         """.format(url=case['data'], name=name, cnt=cnt, tar=tar)
         cp = "$W/{name}/{bench}/target/".format(name=name, bench=data[name]['benchmarks']['path'])
         run += """


### PR DESCRIPTION
Part of #31 
- Fixed file for generation script 
- Added path in archives to `benchmarks.json` as not all archives have flat structure
- Checked validity of existing data by `md5sum` 