### PR TITLE
data: update links to the source archives

### DIFF
--- a/adapters/benchmarks.json
+++ b/adapters/benchmarks.json
@@ -8,26 +8,23 @@
                                 {
                                         "name": "Batch update",
                                         "class": "org.openjdk.jmh.Main",
-                                        "data": "https://artipie.s3.amazonaws.com/rpm-test/bundle100.tar.gz",
+                                        "data": "https://central.artipie.com/artipie/bin/rpm-batch-update.tar.gz",
                                         "args": ["RpmBench"],
-                                        "output": "rpm-batch-update.txt",
-                                        "path-in-tar": "bundle100/"
+                                        "output": "rpm-batch-update.txt"
                                 },
                                 {
                                         "name": "Remove",
                                         "class": "org.openjdk.jmh.Main",
-                                        "data": "https://artipie.s3.amazonaws.com/rpm-test/centos-7-os-x86_64-repodata.tar.gz",
+                                        "data": "https://central.artipie.com/artipie/bin/rpm-metadata-remove.tar.gz",
                                         "args": ["RpmMetadataRemoveBench"],
-                                        "output": "rpm-remove.txt",
-                                        "path-in-tar": ""
+                                        "output": "rpm-remove.txt"
                                 },
                                 {
                                         "name": "Append",
                                         "class": "org.openjdk.jmh.Main",
-                                        "data": "https://artipie.s3.amazonaws.com/rpm-test/rpm-metadata-append-bench.tar.gz",
+                                        "data": "https://central.artipie.com/artipie/bin/rpm-metadata-append.tar.gz",
                                         "args": ["RpmMetadataAppendBench"],
-                                        "output": "rpm-append.txt",
-                                        "path-in-tar": "Downloads/rpm-metadata-append-bench/"
+                                        "output": "rpm-append.txt"
                                 }
                         ]
                 }
@@ -42,17 +39,15 @@
                                         "name": "Merge index",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["IndexMergeBench"],
-                                        "data": "https://artipie.s3.amazonaws.com/debian-test/debian-merge.tar.gz",
-                                        "output": "debian-merge-index.txt",
-                                        "path-in-tar": "Downloads/deb-merge/"
+                                        "data": "https://central.artipie.com/artipie/bin/debian-merge.tar.gz",
+                                        "output": "debian-merge.txt"
                                 },
                                 {
                                         "name": "Repo update",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["RepoUpdateBench"],
-                                        "data": "https://artipie.s3.amazonaws.com/debian-test/debian-repo.tar.gz",
-                                        "output": "debian-merge-index.txt",
-                                        "path-in-tar": "Downloads/deb-packages/"
+                                        "data": "https://central.artipie.com/artipie/bin/debian-repo.tar.gz",
+                                        "output": "debian-update.txt"
                                 }
                         ]
                 }
@@ -66,25 +61,22 @@
                                         "name": "Helm remove",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["HelmAstoRemoveBench"],
-                                        "data": "https://artipie.s3.amazonaws.com/helm-test/helm100.tar.gz",
-                                        "output": "helm-remove.txt",
-                                        "path-in-tar": "bundle100/"
+                                        "data": "https://central.artipie.com/artipie/bin/helm-remove.tar.gz",
+                                        "output": "helm-remove.txt"
                                 },
                                 {
                                         "name": "Helm add",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["HelmAstoAddBench"],
-                                        "data": "https://artipie.s3.amazonaws.com/helm-test/helm100.tar.gz",
-                                        "output": "helm-add.txt",
-                                        "path-in-tar": "bundle100/"
+                                        "data": "https://central.artipie.com/artipie/bin/helm-add.tar.gz",
+                                        "output": "helm-add.txt"
                                 },
                                 {
                                         "name": "Helm reindex",
                                         "class": "org.openjdk.jmh.Main",
                                         "args": ["HelmAstoReindexBench"],
-                                        "data": "https://artipie.s3.amazonaws.com/helm-test/helm100.tar.gz",
-                                        "output": "helm-reindex.txt",
-                                        "path-in-tar": "bundle100/"
+                                        "data": "https://central.artipie.com/artipie/bin/helm-reindex.tar.gz",
+                                        "output": "helm-reindex.txt"
                                 }
                         ]
                 }
@@ -98,26 +90,23 @@
                                 {
                                         "name": "Remove",
                                         "class": "org.openjdk.jmh.Main",
-                                        "data": "https://artipie.s3.amazonaws.com/conda-test/conda-remove.tar.gz",
+                                        "data": "https://central.artipie.com/artipie/bin/conda-remove.tar.gz",
                                         "args": ["CondaRepodataRemoveBench"],
-                                        "output": "conda-remove.txt",
-                                        "path-in-tar": ""
+                                        "output": "conda-remove.txt"
                                 },
                                 {
                                         "name": "Append",
                                         "class": "org.openjdk.jmh.Main",
-                                        "data": "https://artipie.s3.amazonaws.com/conda-test/conda-append.tar.gz",
+                                        "data": "https://central.artipie.com/artipie/bin/conda-append.tar.gz",
                                         "args": ["CondaRepodataAppendBench"],
-                                        "output": "conda-append.txt",
-                                        "path-in-tar": ""
+                                        "output": "conda-append.txt"
                                 },
                                 {
                                         "name": "Merge",
                                         "class": "org.openjdk.jmh.Main",
-                                        "data": "https://artipie.s3.amazonaws.com/conda-test/conda-merge.tar.gz",
+                                        "data": "https://central.artipie.com/artipie/bin/conda-merge.tar.gz",
                                         "args": ["MultiRepodataBench"],
-                                        "output": "conda-merge.txt",
-                                        "path-in-tar": ""
+                                        "output": "conda-merge.txt"
                                 }
                         ]
                 }

--- a/adapters/generate.py
+++ b/adapters/generate.py
@@ -56,28 +56,18 @@ for name in data:
         tar = "$W/_{name}_case{cnt}.tar.gz".format(name=name, cnt=cnt)
         prepare += """
             mkdir -p $W/_{name}_case{cnt}
-            if [ -f {tar} ]; then
-                hashed=$(md5sum {tar} | grep -o '^[^ ]*')
-                hdr=$(curl -I {url} | grep -i Etag | grep -o ' ".*"' | grep -o '[^"]*')
-                if [ $hdr == $hashed ]; then
-                    echo "Data `{tar}` already exists with correct md5sum. It is not necessary to download with curl again."
-                else
-                    curl {url} > {tar}
-                fi
-            else
-                curl {url} > {tar}
-            fi
+            curl -k {url} > {tar}
             tar -xvzf $W/_{name}_case{cnt}.tar.gz -C $W/_{name}_case{cnt}
         """.format(url=case['data'], name=name, cnt=cnt, tar=tar)
         cp = "$W/{name}/{bench}/target/".format(name=name, bench=data[name]['benchmarks']['path'])
         run += """
             echo "running {name} - {case}"
-            env BENCH_DIR=$W/_{name}_case{cnt}/{tar_path} java \\
+            env BENCH_DIR=$W/_{name}_case{cnt} java \\
                 -cp "{cp}benchmarks.jar:{cp}classes/*:{cp}dependency/*" \\
                 {cls} {args} > out/{name}/{out}
         """.format(name=name,
                 case=case['name'], cp=cp, cls=case['class'], args=" ".join(case['args']),
-                out=case['output'], cnt=cnt, tar_path=case['path-in-tar'])
+                out=case['output'], cnt=cnt)
         cnt += 1
     prepare += """
     }


### PR DESCRIPTION
Closes #36 

- Updated links to the source archives. Now they are uploaded Artipie central.
- `tar_path` field was removed  from `benchmarks.json` because now all archives have flat structure
- Checksum check was also removed because Artipie central does not provide method for obtaining md5 sum