### PR TITLE
fix: init variable if file is absent

### DIFF
--- a/adapters/scripts/writeresults.py
+++ b/adapters/scripts/writeresults.py
@@ -63,6 +63,8 @@ if __name__ == '__main__':
     if exists(res_tbl):
         with open(res_tbl, 'r', encoding='utf-8') as f:
             lines = f.readlines()
+    else:
+        lines = []
     with open(res_tbl, 'w', encoding='utf-8') as f:
         for line in lines:
             if line.startswith(f'|{VERSION}') or line.startswith(f'| {VERSION}'):


### PR DESCRIPTION
Part of artipie/artipie#431
If file with results is absent, it is necessary to initialize variable with dummy value.