### PR TITLE
fix: skip tests for benchmark module

### DIFF
--- a/adapters/generate.py
+++ b/adapters/generate.py
@@ -41,7 +41,7 @@ for name in data:
 
     function _{name}_build {{
         mvn install -f $W/{name} -DskipTests
-        mvn package -f $W/{name}/{bench}
+        mvn package -f $W/{name}/{bench} -DskipTests
     }}
     """.format(name=name, repo=data[name]['repo'], bench=data[name]['benchmarks']['path'])
 


### PR DESCRIPTION
Part of artipie/artipie#431
Skip tests for benchmarks module as it now [fails](https://github.com/artipie/helm-adapter/runs/4430028374?check_suite_focus=true#step:4:5046) because tests are absent