### PR TITLE
fix: removed typos, added copying

### DIFF
--- a/adapters/Makefile
+++ b/adapters/Makefile
@@ -32,7 +32,9 @@ run: generate build prepare
 
 write-results: run
 		python3 ./scripts/writeresults.py $(TAG) $(TARGET)
+		cp -av /tmp/artipie-bench/$(TARGET)/benchmarks/results/results.md ../../benchmarks/results/results.md
 
 draw-charts: write-results
-		pip install matplotlib
 		python3 ./scripts/charts.py $(TARGET) $(NUMBER_CHARTS)
+		mkdir -p ../../benchmarks/results/$(TAG)
+		cp -avr ./out/$(TARGET)/* ../../benchmarks/results/$(TAG)

--- a/adapters/scripts/charts.py
+++ b/adapters/scripts/charts.py
@@ -1,6 +1,7 @@
 import argparse
 import matplotlib.pyplot as plt
-from main import VERSION, TABLE_COL, NO_RES, PLUS_MINUS
+from writeresults import VERSION, TABLE_COL, NO_RES, PLUS_MINUS
+from os import sep
 from os.path import join
 
 
@@ -29,7 +30,7 @@ if __name__ == '__main__':
     res_tbl = args.output
     repo_name = args.name
     if res_tbl is None:
-        res_tbl = join(sep, 'tmp', 'artipie-bench', name, 'benchmarks', 'results', 'results.md')
+        res_tbl = join(sep, 'tmp', 'artipie-bench', repo_name, 'benchmarks', 'results', 'results.md')
     rows = {}
     map_col = {}
     with open(res_tbl, 'r', encoding='utf-8') as f:


### PR DESCRIPTION
Part of artipie/artipie#431
Fixed typos in code for drawing charts.
Added code for copying results to eliminate boilerplate code from action. Also it is not necessary to install `matplotlib` as it was already installed on this machine.